### PR TITLE
Added type and argument checks

### DIFF
--- a/modin/data_management/partitioning/partition_collections.py
+++ b/modin/data_management/partitioning/partition_collections.py
@@ -332,8 +332,7 @@ class BlockPartitions(object):
     @classmethod
     def from_pandas(cls, dataframe, num_splits):
         if num_splits is None:
-            from ...pandas import DEFAULT_NPARTITIONS
-            num_splits = DEFAULT_NPARTITIONS
+            num_splits = cls._compute_num_partitions()
 
         pass
 
@@ -353,8 +352,9 @@ class BlockPartitions(object):
             A Pandas Index object.
         """
         if axis == 0:
+            func = self.preprocess_func(lambda df: df.index)
             # We grab the first column of blocks and extract the indices
-            new_indices = [idx.apply(lambda df: df.index).get() for idx in self.partitions.T[0]]
+            new_indices = [idx.apply(func).get() for idx in self.partitions.T[0]]
             # This is important because sometimes we have resized the data. The new
             # sizes will not be valid if we are trying to compute the index on a
             # new object that has a different length.
@@ -363,7 +363,8 @@ class BlockPartitions(object):
             else:
                 cumulative_block_lengths = np.array(self.block_lengths).cumsum()
         else:
-            new_indices = [idx.apply(lambda df: df.columns).get() for idx in self.partitions[0]]
+            func = self.preprocess_func(lambda df: df.columns)
+            new_indices = [idx.apply(func).get() for idx in self.partitions[0]]
 
             if old_blocks is not None:
                 cumulative_block_lengths = np.array(old_blocks.block_widths).cumsum()
@@ -538,6 +539,7 @@ class BlockPartitions(object):
             indices = [indices]
 
         partitions_dict = self._get_dict_of_block_index(axis, indices)
+        preprocessed_func = self.preprocess_func(func)
 
         # Since we might be keeping the remaining blocks that are not modified,
         # we have to also keep the block_partitions object in the correct
@@ -551,10 +553,10 @@ class BlockPartitions(object):
 
         if not keep_remaining:
             # See notes in `apply_func_to_select_indices`
-            result = np.array([partitions_for_apply[i].apply(func, internal_indices=partitions_dict[i]) for i in partitions_dict])
+            result = np.array([partitions_for_apply[i].apply(preprocessed_func, internal_indices=partitions_dict[i]) for i in partitions_dict])
         else:
             # See notes in `apply_func_to_select_indices`
-            result = np.array([partitions_for_remaining[i] if i not in partitions_dict else partitions_for_apply[i].apply(func, internal_indices=partitions_dict[i]) for i in range(len(partitions_for_remaining))])
+            result = np.array([partitions_for_remaining[i] if i not in partitions_dict else partitions_for_apply[i].apply(preprocessed_func, internal_indices=partitions_dict[i]) for i in range(len(partitions_for_remaining))])
 
         return cls(result.T) if not axis else cls(result)
 

--- a/modin/data_management/partitioning/remote_partition.py
+++ b/modin/data_management/partitioning/remote_partition.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import pandas
 import ray
 
 
@@ -167,7 +168,10 @@ class RayRemotePartition(RemotePartition):
         Returns:
             A Pandas DataFrame.
         """
-        return self.get()
+        dataframe = self.get()
+        assert type(dataframe) is pandas.DataFrame()
+
+        return dataframe
 
     @classmethod
     def put(cls, obj):


### PR DESCRIPTION
Made type and argument checks mentioned in comments from the re-write (#70), which is reproduced below:

- [ ] Assert statement for `to_pandas` in `RayRemotePartition` to ensure that the returned object is a dataframe 
- [ ] Assert statements for the kwargs used in the following from `PandasDataManager`
    - concat
    - join_data manager
    - join_list_of_managers
    - reset_index
    - reduction functions (eg count, max , min , mean, prod, sum, any, all, idxmax, idxmin)
- [ ] `inter_manager_operations` from `PandasDataManager` sets reindexed_other and reindexed_self to the same value
- [ ] `from_pandas` in `BlockPartitions` should use `_compute_num_partitions`
- [ ] `get_indicies` and `apply_func_to_select_indices_along_full_axis` in `BlockPartitions` should preprocess the lambda and function, respectively, before passing to to `RemotePartitions` object
- [ ] quantiles functions in `PandasDataManager` should check if the value passed in is a list or value for each respective function


Additionally, type checking was also added to `_join_data_manager` and `_join_list_of_managers`  (from `PandasDataManager`) similar to the checks made in `_append_data_manager` and `_append_list_of_managers`, respectively.
