### PR TITLE
read_csv changes and improvements in performance

### DIFF
--- a/modin/data_management/data_manager.py
+++ b/modin/data_management/data_manager.py
@@ -67,16 +67,16 @@ class PandasDataManager(object):
 
     def _set_index(self, new_index):
         if self._index_cache is None:
-            self._index_cache = new_index
+            self._index_cache = _ensure_index(new_index)
         else:
             new_index = self._validate_set_axis(new_index, self._index_cache)
             self._index_cache = new_index
 
     def _set_columns(self, new_columns):
         if self._columns_cache is None:
-            self._columns_cache = new_columns
+            self._columns_cache = _ensure_index(new_columns)
         else:
-            new_columns = self._validate_set_axis(new_columns, self._index_cache)
+            new_columns = self._validate_set_axis(new_columns, self._columns_cache)
             self._columns_cache = new_columns
 
     columns = property(_get_columns, _set_columns)

--- a/modin/data_management/data_manager.py
+++ b/modin/data_management/data_manager.py
@@ -8,6 +8,7 @@ import pandas
 from pandas.compat import string_types
 from pandas.core.dtypes.cast import find_common_type
 from pandas.core.dtypes.common import (_get_dtype_from_object, is_list_like)
+from pandas.core.index import _ensure_index
 
 from .partitioning.partition_collections import BlockPartitions, RayBlockPartitions
 from .partitioning.remote_partition import RayRemotePartition
@@ -26,7 +27,7 @@ class PandasDataManager(object):
         if dtypes is not None:
             self._dtype_cache = dtypes
 
-    # dtypes
+    # Index, columns and dtypes objects
     _dtype_cache = None
 
     def _get_dtype(self):
@@ -45,35 +46,41 @@ class PandasDataManager(object):
 
     dtypes = property(_get_dtype, _set_dtype)
 
-    # Index and columns objects
     # These objects are currently not distributed.
-    # Note: These are more performant as pandas.Series objects than they are as
-    # pandas.DataFrame objects.
-    #
-    # _index_cache is a pandas.Series that holds the index
     _index_cache = None
-    # _columns_cache is a pandas.Series that holds the columns
     _columns_cache = None
 
     def _get_index(self):
         return self._index_cache
 
     def _get_columns(self):
-        return self._columns_cache.index
+        return self._columns_cache
+
+    def _validate_set_axis(self, new_labels, old_labels):
+        new_labels = _ensure_index(new_labels)
+        old_len = len(old_labels)
+        new_len = len(new_labels)
+        if old_len != new_len:
+            raise ValueError('Length mismatch: Expected axis has %d elements, '
+                             'new values have %d elements' % (old_len, new_len))
+        return new_labels
 
     def _set_index(self, new_index):
-        if self._index_cache is not None:
-            self._index_cache.index = new_index
+        if self._index_cache is None:
+            self._index_cache = new_index
         else:
-            self._index_cache = new_index# pandas.Series(index=new_index)
+            new_index = self._validate_set_axis(new_index, self._index_cache)
+            self._index_cache = new_index
+
     def _set_columns(self, new_columns):
-        if self._columns_cache is not None:
-            self._columns_cache.index = new_columns
+        if self._columns_cache is None:
+            self._columns_cache = new_columns
         else:
-            self._columns_cache = pandas.Series(index=new_columns)
+            new_columns = self._validate_set_axis(new_columns, self._index_cache)
+            self._columns_cache = new_columns
+
     columns = property(_get_columns, _set_columns)
     index = property(_get_index, _set_index)
-
     # END Index, columns, and dtypes objects
 
     def compute_index(self, axis, data_object, compute_diff=True):

--- a/modin/data_management/data_manager.py
+++ b/modin/data_management/data_manager.py
@@ -56,7 +56,7 @@ class PandasDataManager(object):
     _columns_cache = None
 
     def _get_index(self):
-        return self._index_cache.index
+        return self._index_cache
 
     def _get_columns(self):
         return self._columns_cache.index
@@ -65,14 +65,12 @@ class PandasDataManager(object):
         if self._index_cache is not None:
             self._index_cache.index = new_index
         else:
-            self._index_cache = pandas.Series(index=new_index)
-
+            self._index_cache = new_index# pandas.Series(index=new_index)
     def _set_columns(self, new_columns):
         if self._columns_cache is not None:
             self._columns_cache.index = new_columns
         else:
             self._columns_cache = pandas.Series(index=new_columns)
-
     columns = property(_get_columns, _set_columns)
     index = property(_get_index, _set_index)
 
@@ -1011,20 +1009,20 @@ class PandasDataManager(object):
             # ensure that we extract the correct data on each node. The index
             # on a transposed manager is already set to the correct value, so
             # we need to only take the head of that instead of re-transposing.
-            result = cls(self.data.transpose().take(1, n).transpose(), self.index[:n], self.columns, self.dtypes)
+            result = cls(self.data.transpose().take(1, n).transpose(), self.index[:n], self.columns, self._dtype_cache)
             result._is_transposed = True
         else:
-            result = cls(self.data.take(0, n), self.index[:n], self.columns, self.dtypes)
+            result = cls(self.data.take(0, n), self.index[:n], self.columns, self._dtype_cache)
         return result
 
     def tail(self, n):
         cls = type(self)
         # See head for an explanation of the transposed behavior
         if self._is_transposed:
-            result = cls(self.data.transpose().take(1, -n).transpose(), self.index[-n:], self.columns, self.dtypes)
+            result = cls(self.data.transpose().take(1, -n).transpose(), self.index[-n:], self.columns, self._dtype_cache)
             result._is_transposed = True
         else:
-            result = cls(self.data.take(0, -n), self.index[-n:], self.columns, self.dtypes)
+            result = cls(self.data.take(0, -n), self.index[-n:], self.columns, self._dtype_cache)
         return result
 
     def front(self, n):

--- a/modin/data_management/partitioning/partition_collections.py
+++ b/modin/data_management/partitioning/partition_collections.py
@@ -100,7 +100,7 @@ class BlockPartitions(object):
             # The first column will have the correct lengths. We have an
             # invariant that requires that all blocks be the same length in a
             # row of blocks.
-            self._lengths_cache = [obj.length.get() for obj in self.partitions.T[0]]
+            self._lengths_cache = [obj.length().get() for obj in self.partitions.T[0]]
         return self._lengths_cache
 
     # Widths of the blocks
@@ -117,7 +117,7 @@ class BlockPartitions(object):
             # The first column will have the correct lengths. We have an
             # invariant that requires that all blocks be the same width in a
             # column of blocks.
-            self._widths_cache = [obj.width.get() for obj in self.partitions[0]]
+            self._widths_cache = [obj.width().get() for obj in self.partitions[0]]
         return self._widths_cache
 
     def full_reduce(self, map_func, reduce_func, axis):
@@ -703,7 +703,7 @@ class RayBlockPartitions(BlockPartitions):
             # The first column will have the correct lengths. We have an
             # invariant that requires that all blocks be the same length in a
             # row of blocks.
-            self._lengths_cache = ray.get([obj.length.oid for obj in self.partitions.T[0]])
+            self._lengths_cache = ray.get([obj.length().oid for obj in self.partitions.T[0]])
         return self._lengths_cache
 
     # Widths of the blocks
@@ -720,7 +720,7 @@ class RayBlockPartitions(BlockPartitions):
             # The first column will have the correct lengths. We have an
             # invariant that requires that all blocks be the same width in a
             # column of blocks.
-            self._widths_cache = ray.get([obj.width.oid for obj in self.partitions[0]])
+            self._widths_cache = ray.get([obj.width().oid for obj in self.partitions[0]])
         return self._widths_cache
 
     @property

--- a/modin/data_management/partitioning/partition_collections.py
+++ b/modin/data_management/partitioning/partition_collections.py
@@ -672,6 +672,9 @@ class BlockPartitions(object):
         cls = type(self)
         return cls(self.partitions[key])
 
+    def __len__(self):
+        return sum(self.block_lengths)
+
 
 class RayBlockPartitions(BlockPartitions):
     """This method implements the interface in `BlockPartitions`."""

--- a/modin/data_management/partitioning/remote_partition.py
+++ b/modin/data_management/partitioning/remote_partition.py
@@ -117,7 +117,7 @@ class RemotePartition(object):
             func = cls.length_extraction_fn()
             preprocessed_func = cls.preprocess_func(func)
 
-            self._length_cache = self.apply(preprocessed_func).get()
+            self._length_cache = self.apply(preprocessed_func)
         return self._length_cache
 
     @property
@@ -127,7 +127,7 @@ class RemotePartition(object):
             func = cls.width_extraction_fn()
             preprocessed_func = cls.preprocess_func(func)
 
-            self._width_cache = self.apply(preprocessed_func).get()
+            self._width_cache = self.apply(preprocessed_func)
         return self._width_cache
 
 

--- a/modin/data_management/partitioning/remote_partition.py
+++ b/modin/data_management/partitioning/remote_partition.py
@@ -110,7 +110,6 @@ class RemotePartition(object):
     _length_cache = None
     _width_cache = None
 
-    @property
     def length(self):
         if self._length_cache is None:
             cls = type(self)
@@ -120,7 +119,6 @@ class RemotePartition(object):
             self._length_cache = self.apply(preprocessed_func)
         return self._length_cache
 
-    @property
     def width(self):
         if self._width_cache is None:
             cls = type(self)

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -149,7 +149,7 @@ def _read_csv_from_file_pandas_backed_ray(filepath, npartitions, kwargs={}):
         index_ids = []
         total_bytes = os.path.getsize(filepath)
         chunk_size = max(1, (total_bytes - f.tell()) // npartitions)
-        num_splits = RayBlockPartitions._compute_num_partitions()
+        num_splits = min(len(column_names), RayBlockPartitions._compute_num_partitions())
 
         while f.tell() < total_bytes:
             start = f.tell()

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -126,7 +126,7 @@ def _read_csv_from_file_pandas_on_ray(filepath, npartitions, kwargs={}):
         filepath, **dict(kwargs, nrows=0, skipfooter=0, skip_footer=0))
     column_names = empty_pd_df.columns
 
-    skipfooter = kwargs.get("skipfooter", None)
+    skipfooter = kwargs.get("skipfooter", None) or kwargs.get("skip_footer", None)
 
     partition_kwargs = dict(
         kwargs, header=None, names=column_names, skipfooter=0, skip_footer=0)

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import pandas
 from pandas.io.common import _infer_compression
 
+import inspect
 from io import BytesIO
 import os
 import py
@@ -63,11 +64,11 @@ def read_parquet(path, engine='auto', columns=None, **kwargs):
 # CSV
 def _skip_header(f, kwargs={}):
     lines_read = 0
-    comment = kwargs["comment"]
-    skiprows = kwargs["skiprows"]
-    encoding = kwargs["encoding"]
-    header = kwargs["header"]
-    names = kwargs["names"]
+    comment = kwargs.get("comment", None)
+    skiprows = kwargs.get("skiprows", None)
+    encoding = kwargs.get("encoding", None)
+    header = kwargs.get("header", "infer")
+    names = kwargs.get("names", None)
 
     if header is None:
         return lines_read
@@ -110,7 +111,7 @@ def _skip_header(f, kwargs={}):
     return lines_read
 
 
-def _read_csv_from_file_pandas_backed_ray(filepath, npartitions, kwargs={}):
+def _read_csv_from_file_pandas_on_ray(filepath, npartitions, kwargs={}):
     """Constructs a DataFrame from a CSV file.
 
     Args:
@@ -125,15 +126,14 @@ def _read_csv_from_file_pandas_backed_ray(filepath, npartitions, kwargs={}):
         filepath, **dict(kwargs, nrows=0, skipfooter=0, skip_footer=0))
     column_names = empty_pd_df.columns
 
-    skipfooter = kwargs["skipfooter"]
-    skip_footer = kwargs["skip_footer"]
+    skipfooter = kwargs.get("skipfooter", None)
 
     partition_kwargs = dict(
         kwargs, header=None, names=column_names, skipfooter=0, skip_footer=0)
     with open(filepath, "rb") as f:
         # Get the BOM if necessary
         prefix = b""
-        if kwargs["encoding"] is not None:
+        if kwargs.get("encoding", None) is not None:
             prefix = f.readline()
             partition_kwargs["skiprows"] = 1
             f.seek(0, os.SEEK_SET)  # Return to beginning of file
@@ -156,41 +156,26 @@ def _read_csv_from_file_pandas_backed_ray(filepath, npartitions, kwargs={}):
             f.seek(chunk_size, os.SEEK_CUR)
             f.readline()  # Read a whole number of lines
 
-            if f.tell() >= total_bytes:
-                kwargs["skipfooter"] = skipfooter
-                kwargs["skip_footer"] = skip_footer
-
-            partition_id = (_read_csv_with_offset._submit(args=(filepath, num_splits, start, f.tell(), partition_kwargs_id, prefix_id), num_return_vals=num_splits + 1))
+            partition_id = (_read_csv_with_offset_pandas_on_ray._submit(args=(filepath, num_splits, start, f.tell(), partition_kwargs_id, prefix_id), num_return_vals=num_splits + 1))
             partition_ids.append([RayRemotePartition(obj) for obj in partition_id[:-1]])
             index_ids.append(partition_id[-1])
+
     index_col = kwargs.get("index_col", None)
-    print("Submission ended")
     if index_col is None:
         new_index = pandas.RangeIndex(sum(ray.get(index_ids)))
     else:
         new_index_ids = get_index.remote([empty_pd_df.index.name], *index_ids)
         new_index = ray.get(new_index_ids)
 
-    print("Index ended")
     new_manager = PandasDataManager(RayBlockPartitions(np.array(partition_ids)), new_index, column_names)
-    print("New manager created")
-    new_df = DataFrame(data_manager=new_manager)
-    print("New frame created")
-    return new_df
+    df = DataFrame(data_manager=new_manager)
 
-    # Construct index
-    # index_id = get_index.remote([empty_pd_df.index.name], *index_ids) \
-    #     if kwargs["index_col"] is not None else None
-    #
-    # df = DataFrame(row_partitions=partition_ids, columns=names, index=index_id)
-    #
-    # skipfooter = kwargs["skipfooter"] or kwargs["skip_footer"]
-    # if skipfooter:
-    #     df = df.drop(df.index[-skipfooter:])
-    # if kwargs["squeeze"] and len(df.columns) == 1:
-    #     return df[df.columns[0]]
-    #
-    # return df
+    if skipfooter:
+        df = df.drop(df.index[-skipfooter:])
+    if kwargs.get("squeeze", False) and len(df.columns) == 1:
+        return df[df.columns[0]]
+
+    return df
 
 
 def _read_csv_from_pandas(filepath_or_buffer, kwargs):
@@ -269,62 +254,16 @@ def read_csv(filepath_or_buffer,
               We only support local files for now.
         kwargs: Keyword arguments in pandas::from_csv
     """
-
-    kwargs = {
-        'sep': sep,
-        'delimiter': delimiter,
-        'header': header,
-        'names': names,
-        'index_col': index_col,
-        'usecols': usecols,
-        'squeeze': squeeze,
-        'prefix': prefix,
-        'mangle_dupe_cols': mangle_dupe_cols,
-        'dtype': dtype,
-        'engine': engine,
-        'converters': converters,
-        'true_values': true_values,
-        'false_values': false_values,
-        'skipinitialspace': skipinitialspace,
-        'skiprows': skiprows,
-        'nrows': nrows,
-        'na_values': na_values,
-        'keep_default_na': keep_default_na,
-        'na_filter': na_filter,
-        'verbose': verbose,
-        'skip_blank_lines': skip_blank_lines,
-        'parse_dates': parse_dates,
-        'infer_datetime_format': infer_datetime_format,
-        'keep_date_col': keep_date_col,
-        'date_parser': date_parser,
-        'dayfirst': dayfirst,
-        'iterator': iterator,
-        'chunksize': chunksize,
-        'compression': compression,
-        'thousands': thousands,
-        'decimal': decimal,
-        'lineterminator': lineterminator,
-        'quotechar': quotechar,
-        'quoting': quoting,
-        'escapechar': escapechar,
-        'comment': comment,
-        'encoding': encoding,
-        'dialect': dialect,
-        'tupleize_cols': tupleize_cols,
-        'error_bad_lines': error_bad_lines,
-        'warn_bad_lines': warn_bad_lines,
-        'skipfooter': skipfooter,
-        'skip_footer': skip_footer,
-        'doublequote': doublequote,
-        'delim_whitespace': delim_whitespace,
-        'as_recarray': as_recarray,
-        'compact_ints': compact_ints,
-        'use_unsigned': use_unsigned,
-        'low_memory': low_memory,
-        'buffer_lines': buffer_lines,
-        'memory_map': memory_map,
-        'float_precision': float_precision,
-    }
+    # The intention of the inspection code is to reduce the amount of
+    # communication we have to do between processes and nodes. We take a quick
+    # pass over the arguments and remove those that are default values so we
+    # don't have to serialize and send them to the workers. Because the
+    # arguments list is so long, this does end up saving time based on the
+    # number of nodes in the cluster.
+    frame = inspect.currentframe()
+    _, _, _, kwargs = inspect.getargvalues(frame)
+    _, _, _, defaults, _, _, _ = inspect.getfullargspec(read_csv)
+    kwargs = {kw: kwargs[kw] for kw in kwargs if kw in defaults and kwargs[kw] != defaults[kw]}
 
     if isinstance(filepath_or_buffer, str):
         if not os.path.exists(filepath_or_buffer):
@@ -385,7 +324,7 @@ def read_csv(filepath_or_buffer,
 
         return _read_csv_from_pandas(filepath_or_buffer, kwargs)
 
-    return _read_csv_from_file_pandas_backed_ray(filepath_or_buffer, get_npartitions(), kwargs)
+    return _read_csv_from_file_pandas_on_ray(filepath_or_buffer, get_npartitions(), kwargs)
 
 
 def read_json(path_or_buf=None,
@@ -598,13 +537,13 @@ def get_index(index_name, *partition_indices):
 
 
 @ray.remote
-def _read_csv_with_offset(fname, num_splits, start, end, kwargs={}, header=b''):
+def _read_csv_with_offset_pandas_on_ray(fname, num_splits, start, end, kwargs={}, header=b''):
     bio = open(fname, 'rb')
     bio.seek(start)
     to_read = header + bio.read(end - start)
     bio.close()
     pandas_df = pandas.read_csv(BytesIO(to_read), **kwargs)
-    if kwargs["index_col"] is not None:
+    if kwargs.get("index_col", None) is not None:
         index = pandas_df.index
         # Partitions must have RangeIndex
         pandas_df.index = pandas.RangeIndex(0, len(pandas_df))


### PR DESCRIPTION
Updated to the new backend. The structure is similar for sake of consistency.

Generally here is the breakdown of how performance was improved:

- Returning blocks instead of row partitions and subsequently converting those to blocks - ~12% improvement
- Only serializing non-default arguments to reduce communication - ~5%
- Managing index objects instead of using a pandas DataFrame or Series to do it - ~8%

Total gain is ~30%. Reading 20GB on 144 cores takes 16.9 seconds.