### PR TITLE
Push memory_usage entirely to query compiler [change is not to be upstreamed to Modin]

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1245,12 +1245,6 @@ class DataFrame(DataFrameCompat, BasePandasDataset):
         """
         Return the memory usage of each column in bytes.
         """
-        if index:
-            result = self._reduce_dimension(
-                self._query_compiler.memory_usage(index=False, deep=deep)
-            )
-            index_value = self.index.memory_usage(deep=deep)
-            return Series(index_value, index=["Index"]).append(result)
         return super(DataFrame, self).memory_usage(index=index, deep=deep)
 
     def merge(

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1197,13 +1197,7 @@ class Series(SeriesCompat, BasePandasDataset):
         """
         Return the memory usage of the Series.
         """
-        if index:
-            result = self._reduce_dimension(
-                self._query_compiler.memory_usage(index=False, deep=deep)
-            )
-            index_value = self.index.memory_usage(deep=deep)
-            return result + index_value
-        return super(Series, self).memory_usage(index=index, deep=deep)
+        return super(Series, self).memory_usage(index=index, deep=deep).sum()
 
     def mod(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, D200
         """


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io><!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

API layer implementation is not suitable for pushdown:
- For dataframes, we construct `modin.pandas.Series` out of a scalar. We don't intend to support that in product.
- For series, we add in `index.memory_usage()`, which we want to be 0, but `index` on the client side can just be a regular 
pandas `RangeIndex`, in which case it has size 128 regardless of what we do.

Hard to justify accommodating these requirements in OSS, so don't upstream them for now.

- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
