### PR TITLE
FIX: allow updating backend query compilers in place.

### DIFF
--- a/modin/core/execution/client/query_compiler.py
+++ b/modin/core/execution/client/query_compiler.py
@@ -35,6 +35,12 @@ class ClientQueryCompiler(BaseQueryCompiler):
         self._id = id
 
     def _set_columns(self, new_columns):
+        # N.B. almost every query compiler method creates a new compiler, but index and
+        # columns are mutable properties of every query compiler, including the one
+        # we're using in our service now. The service interface allows updating columns
+        # and index in place with set_columns() and set_index(). Maybe in the future
+        # we'd want to cache service results by query compiler ID, in which case
+        # mutating a backend query compiler would not be allowed.
         self._service.set_columns(self._id, new_columns)
         self._columns_cache = self._service.columns(self._id)
 

--- a/modin/core/execution/client/query_compiler.py
+++ b/modin/core/execution/client/query_compiler.py
@@ -35,7 +35,7 @@ class ClientQueryCompiler(BaseQueryCompiler):
         self._id = id
 
     def _set_columns(self, new_columns):
-        self._id = self._service.rename(self._id, new_col_labels=new_columns)
+        self._service.set_columns(self._id, new_columns)
         self._columns_cache = self._service.columns(self._id)
 
     def _get_columns(self):
@@ -44,7 +44,7 @@ class ClientQueryCompiler(BaseQueryCompiler):
         return self._columns_cache
 
     def _set_index(self, new_index):
-        self._id = self._service.rename(self._id, new_row_labels=new_index)
+        self._service.set_index(self._id, new_index)
 
     def _get_index(self):
         return self._service.index(self._id)
@@ -105,7 +105,7 @@ class ClientQueryCompiler(BaseQueryCompiler):
         raise NotImplementedError
 
     def copy(self):
-        return self.__constructor__(self._id)
+        return self.__constructor__(self._service.copy(self._id))
 
     def insert(self, loc, column, value):
         if isinstance(value, ClientQueryCompiler):


### PR DESCRIPTION
**DO NOT MERGE, BUT PLEASE REVIEW**
More details in ponder PR.

Motivation: Align axis update semantics across query compilers. In the base query compiler and even our service's query compiler, you can update the index and columns in place. However, the service gives no way to update axes of a query compiler.

Right now, for inplace updates, service exposes an extra method rename(), and client query compiler uses this to get the id of a new compiler with updated axis, and then updates its id ID of the new query compiler.

This change might be the first to make the service present a mutable interface for a backend query compiler. That seems safe to me, except I had to make copy() get a new query compiler copied from the old query compiler, because we can't let updates to the new query compiler change the original (or vice versa).

Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
