### PR TITLE
REFACTOR: Pass tz_convert, tz_localize directly to query compiler (do not upstream).

### DIFF
--- a/modin/core/execution/client/query_compiler.py
+++ b/modin/core/execution/client/query_compiler.py
@@ -923,6 +923,8 @@ _SINGLE_ID_FORWARDING_METHODS = frozenset(
         "between_time",
         "last",
         "first",
+        "tz_convert",
+        "tz_localize",
     }
 )
 

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2925,15 +2925,13 @@ class BasePandasDataset(BasePandasDatasetCompat):
         """
         Convert tz-aware axis to target time zone.
         """
-        axis = self._get_axis_number(axis)
-        if level is not None:
-            new_labels = (
-                pandas.Series(index=self.axes[axis]).tz_convert(tz, level=level).index
-            )
-        else:
-            new_labels = self.axes[axis].tz_convert(tz)
-        obj = self.copy() if copy else self
-        return obj.set_axis(new_labels, axis, inplace=not copy)
+        # TODO(REFACTOR): original modin implementation uses index.tz_convert and
+        # set_axis(converted_index) Neither of those is implemented in the service and
+        # setting index from a DatabaseIndex is harder. We should implement those and
+        # use the original modin API layer implementation.
+        return self.__constructor__(
+            query_compiler=self._query_compiler.tz_convert(tz, axis, level, copy)
+        )
 
     def tz_localize(
         self, tz, axis=0, level=None, copy=True, ambiguous="raise", nonexistent="raise"
@@ -2941,20 +2939,13 @@ class BasePandasDataset(BasePandasDatasetCompat):
         """
         Localize tz-naive index of a `BasePandasDataset` to target time zone.
         """
-        axis = self._get_axis_number(axis)
-        new_labels = (
-            pandas.Series(index=self.axes[axis])
-            .tz_localize(
-                tz,
-                axis=axis,
-                level=level,
-                copy=False,
-                ambiguous=ambiguous,
-                nonexistent=nonexistent,
+        # TODO(REFACTOR): Find how to reconcile the original modin implementation with
+        # the client-service one.
+        return self.__constructor__(
+            query_compiler=self._query_compiler.tz_localize(
+                tz, axis, level, copy, ambiguous, nonexistent
             )
-            .index
         )
-        return self.set_axis(labels=new_labels, axis=axis, inplace=not copy)
 
     def interpolate(
         self,


### PR DESCRIPTION


Signed-off-by: mvashishtha <mahesh@ponder.io>

Signed-off-by: mvashishtha <mahesh@ponder.io>

Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
