### PR TITLE
FEAT: Remove API layer default for groupby.get_group() (#70) [should upstream]

### DIFF
--- a/modin/core/execution/client/query_compiler.py
+++ b/modin/core/execution/client/query_compiler.py
@@ -949,6 +949,7 @@ _GROUPBY_FORWARDING_METHODS = frozenset(
         "tail",
         "nth",
         "ngroup",
+        "get_group",
         "std",
         "sem",
         "rank",

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -672,7 +672,13 @@ class DataFrameGroupBy(DataFrameGroupByCompat):
         )
 
     def get_group(self, name, obj=None):
-        return self._default_to_pandas(lambda df: df.get_group(name, obj=obj))
+        return self._check_index(
+            self._wrap_aggregation(
+                qc_method=type(self._query_compiler).groupby_get_group,
+                numeric_only=False,
+                agg_kwargs=dict(name=name, obj=obj),
+            )
+        )
 
     def __len__(self):
         return len(self.indices)
@@ -1332,6 +1338,7 @@ class SeriesGroupBy(SeriesGroupByCompat, DataFrameGroupBy):
                 numeric_only=True,
             )
         )
+
 
 if IsExperimental.get():
     from modin.experimental.cloud.meta_magic import make_wrapped_class


### PR DESCRIPTION
<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
