### PR TITLE
FIX: Use nan instead of None for Series.reindex fill_value default [upstream]

### DIFF
--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1428,7 +1428,7 @@ class Series(SeriesCompat, BasePandasDataset):
         copy = kwargs.pop("copy", True)
         limit = kwargs.pop("limit", None)
         tolerance = kwargs.pop("tolerance", None)
-        fill_value = kwargs.pop("fill_value", None)
+        fill_value = kwargs.pop("fill_value", np.nan)
         if kwargs:
             raise TypeError(
                 "reindex() got an unexpected keyword "


### PR DESCRIPTION


<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
