### PR TITLE
FEAT: Change reindex implementation to accomodate ponder index [do not upstream]

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2049,6 +2049,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
         if hasattr(source, "name") and hasattr(destination, "name"):
             destination.name = source.name
         if hasattr(source, "names") and hasattr(destination, "names"):
+            breakpoint()
             destination.names = source.names
         return destination
 
@@ -2082,14 +2083,12 @@ class BasePandasDataset(BasePandasDatasetCompat):
         """
         new_query_compiler = None
         if index is not None:
-            if not isinstance(index, pandas.Index):
-                index = self._copy_index_metadata(
-                    source=self.index, destination=self._ensure_index(index, axis=0)
-                )
-            if not index.equals(self.index):
-                new_query_compiler = self._query_compiler.reindex(
-                    axis=0, labels=index, **kwargs
-                )
+            # TODO: see how/whether to detect modin.pandas index in a better way
+            if hasattr(index, "name") or hasattr(index, "names"):
+                index = self._copy_index_metadata(source=self.index, destination=index)
+            new_query_compiler = self._query_compiler.reindex(
+                axis=0, labels=index, **kwargs
+            )
         if new_query_compiler is None:
             new_query_compiler = self._query_compiler
         final_query_compiler = None

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2082,7 +2082,13 @@ class BasePandasDataset(BasePandasDatasetCompat):
         """
         new_query_compiler = None
         if index is not None:
-            # TODO: see how/whether to detect modin.pandas index in a better way
+            # TODO(REFACTOR): see how/whether to detect modin.pandas index in a better
+            # way. Right now in upsteram modin we always try to convert the index to a
+            # pandas.Index. That is not desirable for large indexes that we store in the
+            # service.
+            # Use duck typing to detect modin.pandas indexes, which are rpyc netrefs.
+            # pandas.Index and modin.pandas.Index and not much else has an attribute
+            # called "_summary".
             if hasattr(index, "_summary"):
                 index = self._copy_index_metadata(source=self.index, destination=index)
             new_query_compiler = self._query_compiler.reindex(

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2049,7 +2049,6 @@ class BasePandasDataset(BasePandasDatasetCompat):
         if hasattr(source, "name") and hasattr(destination, "name"):
             destination.name = source.name
         if hasattr(source, "names") and hasattr(destination, "names"):
-            breakpoint()
             destination.names = source.names
         return destination
 
@@ -2084,7 +2083,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
         new_query_compiler = None
         if index is not None:
             # TODO: see how/whether to detect modin.pandas index in a better way
-            if hasattr(index, "name") or hasattr(index, "names"):
+            if hasattr(index, "_summary"):
                 index = self._copy_index_metadata(source=self.index, destination=index)
             new_query_compiler = self._query_compiler.reindex(
                 axis=0, labels=index, **kwargs


### PR DESCRIPTION
Right now we always try to convert the index to a `pandas.Index`. That is not desirable for large indexes that we store in the service.

Signed-off-by: mvashishtha <mahesh@ponder.io><!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
