### PR TITLE
 FIX: Fix API layer implementation of reindex_like [upstream]

### DIFF
--- a/modin/core/execution/client/query_compiler.py
+++ b/modin/core/execution/client/query_compiler.py
@@ -637,7 +637,6 @@ _BINARY_FORWARDING_METHODS = frozenset(
         "align",
         "series_corr",
         "divmod",
-        "reindex_like",
         "rdivmod",
         "corrwith" "merge_ordered",
     }

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2110,14 +2110,6 @@ class BasePandasDataset(BasePandasDatasetCompat):
             final_query_compiler = new_query_compiler
         return self._create_or_update_from_compiler(final_query_compiler, not copy)
 
-    def reindex_like(
-        self, other, method=None, copy=True, limit=None, tolerance=None
-    ):  # noqa: PR01, RT01, D200
-        """
-        Return an object with matching indices as `other` object.
-        """
-        return self._query_compiler.reindex_like(other, method, copy, limit, tolerance)
-
     def rename_axis(
         self, mapper=None, index=None, columns=None, axis=None, copy=True, inplace=False
     ):  # noqa: PR01, RT01, D200

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2507,6 +2507,30 @@ class DataFrame(DataFrameCompat, BasePandasDataset):
 
         return self._default_to_pandas(style)
 
+    def reindex_like(
+        self: "DataFrame",
+        other,
+        method=None,
+        copy: bool = True,
+        limit=None,
+        tolerance=None,
+    ) -> "DataFrame":
+        # docs say "Same as calling .reindex(index=other.index, columns=other.columns,...).":
+        # https://pandas.pydata.org/pandas-docs/version/1.4/reference/api/pandas.DataFrame.reindex_like.html
+        return self.reindex(
+            index=other.index,
+            method=method,
+            copy=copy,
+            limit=limit,
+            tolerance=tolerance,
+        ).reindex(
+            columns=other.columns,
+            method=method,
+            copy=copy,
+            limit=limit,
+            tolerance=tolerance,
+        )
+
     def _create_or_update_from_compiler(self, new_query_compiler, inplace=False):
         """
         Return or update a ``DataFrame`` with given `new_query_compiler`.

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -2113,6 +2113,24 @@ class Series(SeriesCompat, BasePandasDataset):
 
         return StringMethods(self)
 
+    def reindex_like(
+        self: "Series",
+        other,
+        method=None,
+        copy: bool = True,
+        limit=None,
+        tolerance=None,
+    ) -> "Series":
+        # docs say "Same as calling .reindex(index=other.index, columns=other.columns,...).":
+        # https://pandas.pydata.org/pandas-docs/version/1.4/reference/api/pandas.Series.reindex_like.html
+        return self.reindex(
+            index=other.index,
+            method=method,
+            copy=copy,
+            limit=limit,
+            tolerance=tolerance,
+        )
+
     def _to_pandas(self):
         """
         Convert Modin Series to pandas Series.


### PR DESCRIPTION
Note for upstream and rebase: Don't worry about the client query compiler change here as it's just deleting an unused method. Don't need to upstream or add into the next modin branch on the next rebase.

Signed-off-by: mvashishtha <mahesh@ponder.io>